### PR TITLE
Add delete method to CORS allowed requests.

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,5 +1,5 @@
 class Service < ApplicationRecord
-  validates :name, presence: true, uniqueness: true, length: { minimum: 4 }
+  validates :name, presence: true, uniqueness: true, length: { in: 4..50 }
   validates :description, presence: true, length: { maximum: 250 }
   validates :price, presence: true
   validates :image_url, presence: true, format: URI::DEFAULT_PARSER.make_regexp(%w[http https])

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,7 +10,6 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins '*'
-    resource '*', headers: :any, methods: [:get, :post, :patch, :put]
+    resource '*', headers: :any, methods: [:get, :post, :delete]
   end
 end
-


### PR DESCRIPTION
# What?
Fix pull request to add delete method to CORS allowed methods.

# Before merging
- [x] Add delete method to CORS allowed methods.
- [x] Change service name validation to match the frontend (between 4 and 50 characters).